### PR TITLE
Fix to work with Browserify (vueify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ new Vue({
 </script>
 ```
 <br>
-Use in vue2.x 
+Use in vue2.x
 <br>Because```.sync``` was deprecated. Props are now always one-way down. So in order to realize the two-way, Can be set in the @callback
 
 e.g:
@@ -101,6 +101,15 @@ new Vue({
 });
 </script>
 ```
+<br>
+Use with Browserify (vueify)
+<br>Use this little fix:
+
+e.g:
+```js
+import vueSlider from 'vue-slider-component/src/vue2-slider.vue'
+```
+
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "vue-loader": "^8.5.3",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.13.1"
+  },
+  "browserify": {
+    "transform": ["vueify"]
   }
 }

--- a/src/vue2-slider.vue
+++ b/src/vue2-slider.vue
@@ -4,18 +4,18 @@
 			<div ref="wrap" :class="['vue-slider-wrap', flowDirection, className, disabledClass]" v-show="show" :style="[( styles || {} ), wrapStyles]" @click="wrapClick">
 				<div ref="elem" class="vue-slider" :style="elemStyles">
 					<template v-if="isRange">
-						<div ref="dot0" :data-rangeValue="value[0]" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart(0)"></div>
-						<div ref="dot1" :data-rangeValue="value[1]" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart(1)"></div>
+						<div ref="dot0" :data-rangeValue="value[0]" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart(0)"></div>
+						<div ref="dot1" :data-rangeValue="value[1]" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart(1)"></div>
 					</template>
 					<template v-else>
-						<div ref="dot" :data-rangeValue="value" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart"></div>
+						<div ref="dot" :data-rangeValue="value" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @touchstart="moveStart"></div>
 					</template>
 					<template v-if="piecewise">
 						<ul v-if="direction === 'vertical'" class="vue-slider-piecewise">
-							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { bottom: `${ gap * i - width / 2 }px`, left: '0px' }]"></li>
+							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { bottom: gap * i - width / 2 + 'px', left: '0px' }]"></li>
 						</ul>
 						<ul v-else class="vue-slider-piecewise">
-							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { left: `${ gap * i - height / 2 }px`, top: '0px' }]"></li>
+							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { left: gap * i - height / 2 + 'px', top: '0px' }]"></li>
 						</ul>
 					</template>
 					<span ref="process" class="vue-slider-process"></span>
@@ -26,18 +26,18 @@
 			<div ref="wrap" :class="['vue-slider-wrap', flowDirection, className, disabledClass]" v-show="show" :style="[( styles || {} ), wrapStyles]" @click="wrapClick">
 				<div ref="elem" class="vue-slider" :style="elemStyles">
 					<template v-if="isRange">
-						<div ref="dot0" :data-rangeValue="value[0]" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart(0)"></div>
-						<div ref="dot1" :data-rangeValue="value[1]" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart(1)"></div>
+						<div ref="dot0" :data-rangeValue="value[0]" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart(0)"></div>
+						<div ref="dot1" :data-rangeValue="value[1]" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart(1)"></div>
 					</template>
 					<template v-else>
-						<div ref="dot" :data-rangeValue="value" :class="[ tooltipStatus, `vue-slider-tooltip-${tooltipDirection}`, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart"></div>
+						<div ref="dot" :data-rangeValue="value" :class="[ tooltipStatus, 'vue-slider-tooltip-' + tooltipDirection, 'vue-slider-dot']" :style="dotStyles" @mousedown="moveStart"></div>
 					</template>
 					<template v-if="piecewise">
 						<ul v-if="direction === 'vertical'" class="vue-slider-piecewise">
-							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { bottom: `${ gap * i - width / 2 }px`, left: '0px' }]"></li>
+							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { bottom: gap * i - width / 2 + 'px', left: '0px' }]"></li>
 						</ul>
 						<ul v-else class="vue-slider-piecewise">
-							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { left: `${ gap * i - height / 2 }px`, top: '0px' }]"></li>
+							<li v-for="i in (total - 1)" :style="[ piecewiseStyle, { left: gap * i - height / 2 + 'px', top: '0px' }]"></li>
 						</ul>
 					</template>
 					<span ref="process" class="vue-slider-process"></span>


### PR DESCRIPTION
Add **vueify** transform to `package.json` and substitute template string for expressions, to _vue-slider-component_ work with **Browserify** (#6). And, add a note in README.