### PR TITLE
Auto enable vue-slider-component when in a production enviroment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,12 @@
 var vueSlider = require('./vue2-slider')
 
+// Install by default if included from script tag
+if (typeof window !== 'undefined' && window.Vue) {
+  function install (Vue) {
+    Vue.component('vue-slider', vueSlider);
+  }
+
+  window.Vue.use(install)
+}
+
 module.exports = vueSlider


### PR DESCRIPTION
With this change we just need to add script tag:

```html
	<script src="built-file.js" charset="utf-8"></script>
```

And we can use the component even in vanilla JS enviroment