### PR TITLE
SSR Readme Instructions: Updated Variable Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ let components = {
 
 3. Require the library just for client side and add the 'vue-slider-component' component to the template component list
 ```js
-if (process.BROWSER_BUILD) {
+if (process.browser) { 
+    // in older versions of nuxt, it's process.BROWSER_BUILD
     let VueSlider = require('vue-slider-component')
     components['vue-slider'] = VueSlider
 }


### PR DESCRIPTION
Hey! I love this component; thanks for it.

I had an issue with server-side rendering using Nuxt. Nuxt has dropped `process.BROWSER_BUILD` and made it `process.browser` for their 1.0 release. This PR updates your readme to reflect the change, with a comment for people using older versions of nuxt.