### PR TITLE
add max-index to label slot scope

### DIFF
--- a/src/vue2-slider.vue
+++ b/src/vue2-slider.vue
@@ -179,6 +179,7 @@
             :first="index === 0"
             :last="index === piecewiseDotWrap.length - 1"
             :active="isActive(piecewiseObj.index)"
+            :max-index="piecewiseDotWrap.length - 1"
           >
             <span
               v-if="piecewiseLabel"


### PR DESCRIPTION
For dynamic data (when you can't be sure on how much data you get) to be displayed with the slider, you need information about the data for the label, to choose when to create a label.
Thus I added a max index to the slot scope.