### PR TITLE
Drag the handle by clicking anywhere in the component

### DIFF
--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -97,7 +97,7 @@ export default class VueSlider extends Vue {
   @Prop({ type: Boolean, default: true })
   clickable!: boolean
 
-  @Prop({ type: Boolean, default: true })
+  @Prop({ type: Boolean, default: false })
   dragOnClick!: boolean
 
   // The duration of the slider slide, Unit second


### PR DESCRIPTION
The core functionality does not allows users to click anywhere on the slider rail and also start the dragging process, which could be desirable from a UX standpoint.

I added a new prop `dragOnClick` and functionality which if set to true, should allow the user to start the dragging process (snaps the closes handle, even in range mode) if the user clicks the rail or the marks in the component.

Please feel free to comment on this PR regarding the naming and the added functionality.