### PR TITLE
feat: add "value" to default scope slot

### DIFF
--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -779,7 +779,7 @@ export default class VueSlider extends Vue {
               {this.renderSlot<Dot>('tooltip', dot, null)}
             </vue-slider-dot>
           ))}
-          {this.renderSlot<any>('default', null, null, true)}
+          {this.renderSlot<any>('default', { value: this.getValue() }, null, true)}
         </div>
       </div>
     )

--- a/src/examples/simple.ts
+++ b/src/examples/simple.ts
@@ -121,6 +121,31 @@ export default {
   }
 </script>
   `,
+  example_lazy_but_with_current_values: `
+<template>
+  <div>
+    <div>value: {{ value }}</div>
+    <vue-slider v-model="value" :lazy="true">
+      <div slot-scope="{ value }" style="padding-top: 16px">
+        Current value: {{ value }}
+      </div>
+    </vue-slider>
+  </div>
+</template>
+
+<script>
+  module.exports = {
+    components: {
+      VueSlider
+    },
+    data: function () {
+      return {
+        value: 0
+      }
+    }
+  }
+</script>
+  `,
   example6: `
 <template>
   <div>

--- a/src/pages/Basics/Simple.md
+++ b/src/pages/Basics/Simple.md
@@ -27,6 +27,8 @@ The value will only be updated when the drag is over
 
 <example :value="example5"></example>
 
+<example :value="example_lazy_but_with_current_values"></example>
+
 ### Disabled slider
 
 You can disable the entire component with `disabled` or disable the slider separately with `dot-options`


### PR DESCRIPTION
Hi :wave: 

First let me thank you for this library, we are using it on multiple projects and we are really happy about it!

---

We are working with [Algolia Vue InstantSearch](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/) and we created a custom [range slider](https://www.algolia.com/doc/api-reference/widgets/range-slider/vue).

It looks like this and it works fine:
```vue
<template>
  <AisRangeInput v-bind="$attrs">
    <div slot-scope="{ currentRefinement, range, refine }">
      <vue-slider
        :min="range.min"
        :max="range.max"
        :value="toValue(currentRefinement, range)"
        lazy
        contained
        tooltip="none"
        @change="(event) => refine({ min: event[0], max: event[1] })"
      />
    </div>
  </AisRangeInput>
</template>

<script>
// not interesting
</script>
```

However, we want to display the current slider's value while dragging and when `lazy` enabled (which prevent useless and _costly_ `refine()` calls, to Algolia), like the following screens:

![Sélection_723](https://user-images.githubusercontent.com/2103975/82922289-b2eda780-9f79-11ea-9743-2179d0f7089e.png)

![Sélection_724](https://user-images.githubusercontent.com/2103975/82922286-b2551100-9f79-11ea-91ef-d37c2fe838b8.png)

I was able to make it working by:
- putting a reference to `vue-slider` component (`slider`)
- creating a computed `sliderValue()` which returns `getValue()` from ref `slider`
- using [`vue-reactive-refs`](https://github.com/posva/vue-reactive-refs) since ref are not reactive

```diff
<template>
  <AisRangeInput v-bind="$attrs">
    <div slot-scope="{ currentRefinement, range, refine }">
      <vue-slider
+       ref="slider"
        :min="range.min"
        :max="range.max"
        :value="toValue(currentRefinement, range)"
        lazy
        contained
        tooltip="none"
        @change="(event) => refine({ min: event[0], max: event[1] })"
      />
    </div>
  </AisRangeInput>
</template>

<script>
export default {
+   refs: ['slider'],
    // ...
+  computed: {
+    sliderValue() {
+      return this.$refs.slider && this.$refs.slider.getValue();
+    }
+  },
}
</script>
```

An other alternative would be to remove `lazy` property and use a custom debounce function for Algolia's `refine`, but I don't know if it will works since `refine` is a scoped props... And I don't want to use a ref, the less you use them, the better you feel :sweat_smile: 

I think you will agree with me that both solution are not ideal. In this PR, I propose to send `getValue()` to the `default` slot's scope:

```vue
<vue-slider lazy>
  <div slot-scope="{ value }">
    Current value: {{ value }}
  </div>
</vue-slider>
```

What do you think?
Thank!