### PR TITLE
feat: allow max value to not match interval

### DIFF
--- a/src/pages/Api/Props.md
+++ b/src/pages/Api/Props.md
@@ -188,7 +188,7 @@
   The interval between two values.
 
   ::: tip
-    The value must be greater than 0 and can be divisible by (max - min).
+    The value must be greater than 0. If `(max - min) % interval` does not return zero, the max value will be added.
   :::
 
 ### disabled

--- a/tests/unit/control.spec.ts
+++ b/tests/unit/control.spec.ts
@@ -57,6 +57,25 @@ describe('Control', () => {
     expect(control.isActiveByPos(40)).to.equal(true)
     expect(control.isActiveByPos(80)).to.equal(false)
   })
+  it('Method: getValues & max % interval != 0', () => {
+    const control = getControl()
+    control.min = 1
+    control.max = 7
+    control.interval = 5
+    control.setValue(5)
+    expect(control.isActiveByPos(7)).to.equal(true)
+    expect(control.getValues().length).to.equal(3)
+  })
+  it('Method: getValueByIndex when max % interval != 0', () => {
+    const control = getControl()
+    control.min = 1
+    control.max = 7
+    control.interval = 5
+    control.setValue(5)
+    expect(control.getValueByIndex(0)).to.equal(1)
+    expect(control.getValueByIndex(1)).to.equal(6)
+    expect(control.getValueByIndex(2)).to.equal(7)
+  })
   it('Param: minRange', () => {
     const control = getControl()
     control.setValue([0, 100])


### PR DESCRIPTION
I have a requirement where the `(max - min) % interval == 0` condition is not met. This MR removes this condition.