### PR TITLE
Correct spelling for license

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vue-component",
     "vue-slider-component"
   ],
-  "licenses": "MIT",
+  "license": "MIT",
   "lint-staged": {
     "*.{js,ts,tsx,scss}": [
       "npm run prettier",


### PR DESCRIPTION
NPM shows this as not having a licence

![image](https://user-images.githubusercontent.com/1102850/93210519-ad4de480-f757-11ea-8c22-93bc4c1ac5f9.png)
