### PR TITLE
fix: rename handler from onDrag-start to onDragStart

### DIFF
--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -854,7 +854,7 @@ export default class VueSlider extends Vue {
                     transition: `${this.mainDirection} ${this.animateTime}s`,
                   },
                 ]}
-                onDrag-start={() => this.dragStart(index)}
+                onDragStart={() => this.dragStart(index)}
                 role="slider"
                 aria-valuenow={dot.value}
                 aria-valuemin={this.min}


### PR DESCRIPTION
With Vue 3 I was no longer able to use dragging to change the value of the slide – I could only use keyboard controls or clicking anywhere in the slider. I found out that the `drag-start` was not handled properly.

For some reason Vue 3 is not recognizing the `@Drag-start` (`onDrag-start`) event emitted by `<vue-slider-dot>`.  This lead into an issue that the `drag-start` event has not been handled and the value change only happed after dragging / clicking anywhere inside the slider.

Removing the `-` and therefore rename the handler to `onDragStart` fixes the issue.