### PR TITLE
add passive: false option to mousemove (dragMove) event

### DIFF
--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -426,7 +426,7 @@ export default class VueSlider extends Vue {
     document.addEventListener('touchmove', this.dragMove, { passive: false })
     document.addEventListener('touchend', this.dragEnd, { passive: false })
     document.addEventListener('mousedown', this.blurHandle)
-    document.addEventListener('mousemove', this.dragMove)
+    document.addEventListener('mousemove', this.dragMove, { passive: false })
     document.addEventListener('mouseup', this.dragEnd)
     document.addEventListener('mouseleave', this.dragEnd)
     document.addEventListener('keydown', this.keydownHandle)


### PR DESCRIPTION
When moving the slider following console error occurs: Unable to preventDefault inside passive event listener invocation.
@NightCatSama maybe you can check out my PR. I already tested the fix. 