### PR TITLE
fix: getRecentDot ignores disabled dots

### DIFF
--- a/lib/utils/control.ts
+++ b/lib/utils/control.ts
@@ -204,7 +204,9 @@ export default class Control {
    * @memberof Control
    */
   getRecentDot(pos: number): number {
-    const arr = this.dotsPos.map(dotPos => Math.abs(dotPos - pos))
+    const arr = this.dotsPos
+      .filter((dotPos, index) => !(this.getDotOption(index) && this.getDotOption(index)!.disabled))
+      .map(dotPos => Math.abs(dotPos - pos))
     return arr.indexOf(Math.min(...arr))
   }
 
@@ -536,12 +538,16 @@ export default class Control {
     return (this.cacheRangeDir[this.maxRange] = this.getRangeDir(this.maxRange))
   }
 
+  private getDotOption(index: number): DotOption | undefined {
+    return Array.isArray(this.dotOptions) ? this.dotOptions[index] : this.dotOptions
+  }
+
   private getDotRange(index: number, key: 'min' | 'max', defaultValue: number): number {
     if (!this.dotOptions) {
       return defaultValue
     }
 
-    const option = Array.isArray(this.dotOptions) ? this.dotOptions[index] : this.dotOptions
+    const option = this.getDotOption(index)
     return option && option[key] !== void 0 ? this.parseValue(option[key] as Value) : defaultValue
   }
 


### PR DESCRIPTION
Hello, i had an issue with multiple dots on slider and some of them being disabled. Then clicking on the slider would sometimes move one of the enabled dots, but sometimes wouldn't do anything - that was in the case, when the closest dot (which would normally move) was disabled.

I propose a fix which ignores disabled dots when looking for the closest dot (getRecentDot function).

Thanks

Petr Kratochvíl