### PR TITLE
fix: getRecentDot: corrected search for nearest enabled dot

### DIFF
--- a/lib/utils/control.ts
+++ b/lib/utils/control.ts
@@ -203,11 +203,17 @@ export default class Control {
    * @returns {number}
    * @memberof Control
    */
-  getRecentDot(pos: number): number {
+  getRecentDot(pos: number): number | undefined {
     const arr = this.dotsPos
-      .filter((dotPos, index) => !(this.getDotOption(index) && this.getDotOption(index)!.disabled))
-      .map(dotPos => Math.abs(dotPos - pos))
-    return arr.indexOf(Math.min(...arr))
+      .map((dotPos, dotIndex) => {
+        return { dotIndex, distance: Math.abs(dotPos - pos) }
+      })
+      .filter(
+        ({ dotIndex }) => !(this.getDotOption(dotIndex) && this.getDotOption(dotIndex)!.disabled),
+      )
+    const minDistance = Math.min(...arr.map(({ distance }) => distance))
+    const nearestDot = arr.find(({ distance }) => distance === minDistance)
+    return nearestDot ? nearestDot!.dotIndex : undefined
   }
 
   /**

--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -564,7 +564,7 @@ export default class VueSlider extends Vue {
       this.setScale()
       const pos = this.getPosByEvent(e)
       const index = this.control.getRecentDot(pos)
-      if (this.dots[index].disabled) {
+      if (index === undefined) {
         return
       }
       this.dragStart(index)
@@ -700,7 +700,7 @@ export default class VueSlider extends Vue {
 
   setValueByPos(pos: number) {
     const index = this.control.getRecentDot(pos)
-    if (this.disabled || this.dots[index].disabled) {
+    if (index === undefined || this.disabled) {
       return false
     }
     this.focusDotIndex = index


### PR DESCRIPTION
Hello, I had to make a correction of searching for the nearest enabled dot. In the previous version, when disabled dots got filtered out, the indices in the array were shifted. So in this correction, the indices are preserved during the filter operation. Thank you for the merge, Petr.