### PR TITLE
Fix Sass deprecation warning

### DIFF
--- a/lib/styles/_triangle.scss
+++ b/lib/styles/_triangle.scss
@@ -4,7 +4,7 @@
   @if ($direction==top) or ($direction==bottom) or ($direction==right) or ($direction==left) {
     border-color: transparent;
     border-style: solid;
-    border-width: $size / 2;
+    border-width: $size * 0.5;
     @if $direction==top {
       border-bottom-color: $color;
     } @else if $direction==right {


### PR DESCRIPTION
Fix for deprecation when using dart-sass.

Alternative to using `math.div` is to simply `* 0.5`

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($size, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
7 │     border-width: $size / 2;
```