### PR TITLE
use calc() for multiplication to avoid warnings in recent Dart Sass v…

### DIFF
--- a/lib/styles/_triangle.scss
+++ b/lib/styles/_triangle.scss
@@ -4,7 +4,7 @@
   @if ($direction==top) or ($direction==bottom) or ($direction==right) or ($direction==left) {
     border-color: transparent;
     border-style: solid;
-    border-width: $size * 0.5;
+    border-width: calc($size * 0.5);
     @if $direction==top {
       border-bottom-color: $color;
     } @else if $direction==right {


### PR DESCRIPTION
Fix for this warning:

`Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.`