### PR TITLE
Add component names

### DIFF
--- a/lib/vue-slider-dot.tsx
+++ b/lib/vue-slider-dot.tsx
@@ -3,7 +3,7 @@ import { Value, Styles, Position, TooltipProp, TooltipFormatter } from './typing
 
 import './styles/dot.scss'
 
-@Component
+@Component({ name: 'VueSliderDot' })
 export default class VueSliderDot extends Vue {
   $refs!: {
     dot: HTMLDivElement

--- a/lib/vue-slider-mark.tsx
+++ b/lib/vue-slider-mark.tsx
@@ -3,7 +3,7 @@ import { Mark, Styles } from './typings'
 
 import './styles/mark.scss'
 
-@Component
+@Component({ name: 'VueSlideMark' })
 export default class VueSlideMark extends Vue {
   @Prop({ required: true })
   mark!: Mark

--- a/lib/vue-slider.tsx
+++ b/lib/vue-slider.tsx
@@ -35,6 +35,7 @@ export const SliderState: StateMap = {
 const DEFAULT_SLIDER_SIZE = 4
 
 @Component({
+  name: 'VueSlider',
   data() {
     return {
       control: null,


### PR DESCRIPTION
The components without names get invalid names when minified.
So the following warning is shown in a browser console.

```
[Vue warn]: Invalid component name: "_e". Component names should conform to valid custom element name in html5 specification.
```

https://stackoverflow.com/questions/51858251/vue-warn-invalid-component-name-after-uglify