### PR TITLE
feat(slider): add the ability to disable tabindex

### DIFF
--- a/lib/vue-slider.vue
+++ b/lib/vue-slider.vue
@@ -88,7 +88,7 @@
         :aria-valuemin="min"
         :aria-valuemax="max"
         :aria-orientation="isHorizontal ? 'horizontal' : 'vertical'"
-        tabindex="0"
+        :tabindex="disableTabs ? -1 : 0"
         @focus="() => focus(dot, index)"
         @blur="() => blur()"
         v-bind="dotAttrs"
@@ -288,6 +288,9 @@ export default defineComponent({
     labelStyle: { type: Object as PropType<Styles> },
 
     labelActiveStyle: { type: Object as PropType<Styles> },
+
+    // If the value is true , pressing tab will not select the slider dots
+    disableTabs: { type: Boolean },
   },
   computed: {
     isHorizontal(): boolean {

--- a/src/pages/Api/Props.md
+++ b/src/pages/Api/Props.md
@@ -632,3 +632,19 @@
 - **Usage**:
 
   The style of the label activation state.
+
+## disableTabs
+
+- **Type**: `boolean`
+
+- **Default**: `false`
+
+- **Usage**:
+
+  ```html
+  <vue-slider disable-tabs />
+  ```
+
+  By default, each slider dot will be highlighted when pressing tab.
+
+  If the value is `true`, slider dots be ignored when pressing tab.


### PR DESCRIPTION
This adds a `disable-tabs` prop which sets `tabindex="-1"` on all slider dots so they no longer listen for the tab key press. The default behaviour of vue slider component is not affected.

I've only added english docs as I don't know Chinese and machine translation isn't often good.

Fixes #650