### PR TITLE
Fix calc error from Lexer "Unrecognized text"

### DIFF
--- a/lib/styles/_triangle.scss
+++ b/lib/styles/_triangle.scss
@@ -4,7 +4,7 @@
   @if ($direction==top) or ($direction==bottom) or ($direction==right) or ($direction==left) {
     border-color: transparent;
     border-style: solid;
-    border-width: calc($size * 0.5);
+    border-width: calc(#{$size} * 0.5);
     @if $direction==top {
       border-bottom-color: $color;
     } @else if $direction==right {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8521882/199459987-7ad5a564-19e2-4ad7-9093-c3ccb0c25918.png)

This fixes compile error because variables in calc is expected to be wrapped in #{}