### PR TITLE
fix: drag-start + press-label not emitting due to case naming differences

### DIFF
--- a/lib/vue-slider-dot.vue
+++ b/lib/vue-slider-dot.vue
@@ -27,7 +27,7 @@ import './styles/dot.scss';
 
 export default defineComponent({
   name: 'VueSliderDot',
-  emits: ['DragStart'],
+  emits: ['drag-start'],
   props: {
     value: { type: [String, Number] as PropType<Value>, default: 0 },
 
@@ -122,7 +122,7 @@ export default defineComponent({
         return false
       }
 
-      this.$emit('DragStart')
+      this.$emit('drag-start')
     },
   }
 })

--- a/lib/vue-slider-mark.vue
+++ b/lib/vue-slider-mark.vue
@@ -39,7 +39,7 @@ import './styles/mark.scss';
 
 export default defineComponent({
   name: 'VueSliderMark',
-  emits: ['PressLabel'],
+  emits: ['press-label'],
   props: {
     mark: {
       type: Object as PropType<Mark>,
@@ -85,7 +85,7 @@ export default defineComponent({
   methods: {
     labelClickHandle(e: MouseEvent | TouchEvent) {
       e.stopPropagation()
-      this.$emit('PressLabel', this.mark.pos)
+      this.$emit('press-label', this.mark.pos)
     },
   }
 })

--- a/lib/vue-slider.vue
+++ b/lib/vue-slider.vue
@@ -42,7 +42,7 @@
             :stepActiveStyle="stepActiveStyle"
             :labelStyle="labelStyle"
             :labelActiveStyle="labelActiveStyle"
-            :onPressLabel="(pos: number) => clickable && setValueByPos(pos)"
+            @press-label="(pos: number) => clickable && setValueByPos(pos)"
           >
             <template v-slot:step><slot name="step" v-bind="mark"></slot></template>
             <template v-slot:label><slot name="label" v-bind="mark"></slot></template>


### PR DESCRIPTION
When you converted between TSX + Vue SFC files, I think you missed some of the changes in event naming conventions.

Quick explanation: camelCase and kebab-case can be used interchangeably, but TitleCase does not work as events are passed as props prefixed with on, so `onDragEvent`-> event is `dragEvent`. This is why `:onPressLabel` is working in `vue-slider.vue` but `@drag-start` is not firing from `vue-slider-dor.vue`.

This PR uses kebab case everywhere instead of both the `:onEventName` and `@event-name` syntax.